### PR TITLE
docs(readme): fix license references from MIT to Apache 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ All changes to `main` and `develop` go through Pull Requests with CI approval.
 
 ### License
 
-This project is licensed under the [MIT License](LICENSE).
+This project is licensed under the [Apache License 2.0](LICENSE).
 
 ---
 
@@ -541,4 +541,4 @@ Todos los cambios a `main` y `develop` pasan por Pull Requests con aprobación d
 
 ### Licencia
 
-Este proyecto está bajo la [Licencia MIT](LICENSE).
+Este proyecto está bajo la [Licencia Apache 2.0](LICENSE).


### PR DESCRIPTION
## Description

README footer sections (English & Spanish) incorrectly referenced MIT License while the actual LICENSE file and badge are Apache 2.0.

## Changes

| File | Change |
|------|--------|
| `README.md` | Line 278: MIT License → Apache License 2.0 |
| `README.md` | Line 544: Licencia MIT → Licencia Apache 2.0 |

## Type of Change

- [x] `docs` — Documentation update

## Testing

- [x] Verified no remaining MIT references in codebase
- [x] Badge (line 11) already says Apache 2.0 — now consistent