### PR TITLE
feat(frontend): heartbeat y detección de stale data

### DIFF
--- a/frontend/src/components/dashboard/Header.tsx
+++ b/frontend/src/components/dashboard/Header.tsx
@@ -1,12 +1,22 @@
 'use client';
 
+import { ConnectionStatus } from '@/lib/types';
+
 interface HeaderProps {
-  connected: boolean;
+  connected: ConnectionStatus;
   active: boolean;
   onStop: () => void;
 }
 
+const STATUS_CONFIG: Record<ConnectionStatus, { dot: string; label: string; text: string }> = {
+  CONNECTED:    { dot: 'bg-status-ok shadow-[0_0_8px_var(--color-status-ok)] animate-pulse', label: 'LIVE',         text: 'text-status-ok' },
+  CONNECTING:   { dot: 'bg-status-warn animate-pulse',                                        label: 'CONNECTING…',  text: 'text-status-warn' },
+  STALE:        { dot: 'bg-status-warn',                                                      label: 'STALE',        text: 'text-status-warn' },
+  DISCONNECTED: { dot: 'bg-text-muted',                                                       label: 'OFFLINE',      text: 'text-text-muted' },
+};
+
 export function Header({ connected, active, onStop }: HeaderProps) {
+  const { dot, label, text } = STATUS_CONFIG[connected] ?? STATUS_CONFIG.DISCONNECTED;
   return (
     <header className="flex items-center justify-between px-6 py-3 bg-[#111111] border-b border-border-subtle shrink-0">
       <div className="flex items-center gap-3">
@@ -20,14 +30,8 @@ export function Header({ connected, active, onStop }: HeaderProps) {
 
       <div className="flex items-center gap-4 text-sm font-semibold">
         <div className="flex items-center gap-2">
-          <div
-            className={`w-2.5 h-2.5 rounded-full ${
-              connected ? 'bg-status-ok shadow-[0_0_8px_var(--color-status-ok)] animate-pulse' : 'bg-text-muted'
-            }`}
-          />
-          <span className={connected ? 'text-status-ok' : 'text-text-muted'}>
-            {connected ? 'LIVE' : 'OFFLINE'}
-          </span>
+          <div className={`w-2.5 h-2.5 rounded-full ${dot}`} />
+          <span className={text}>{label}</span>
         </div>
 
         {active && (

--- a/frontend/src/hooks/useMonitor.ts
+++ b/frontend/src/hooks/useMonitor.ts
@@ -1,29 +1,27 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { MonitorState, UnifiedEvent } from '@/lib/types';
+import { ConnectionStatus, MonitorState, UnifiedEvent } from '@/lib/types';
 
 const SSE_URL = '/api/events/stream';
 const MAX_LOG_ENTRIES = 100;
+const STALE_THRESHOLD_MS = 15_000;
+const RECONNECT_THRESHOLD_MS = 30_000;
 
-/**
- * Custom hook that manages the EventSource (SSE) connection to the Spring Boot
- * backend.  It separates incoming events into infrastructure status and data
- * log entries, updating the shared monitor state accordingly.
- *
- * The connection is only opened after the user clicks "Start Monitoring" so
- * that the AudioContext can be created in a user-gesture callback.
- */
 export function useMonitor() {
   const [state, setState] = useState<MonitorState>({
     infrastructure: [],
     logs: [],
-    connected: false,
+    connected: 'DISCONNECTED',
+    lastEventTimestamp: 0,
   });
   const [active, setActive] = useState(false);
+  const [reconnectKey, setReconnectKey] = useState(0);
 
   const esRef = useRef<EventSource | null>(null);
   const audioCtxRef = useRef<AudioContext | null>(null);
+  const lastEventRef = useRef<number>(0);
+  const staleTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // ── Audio helpers ────────────────────────────────────────────────────────
   const initAudio = useCallback(() => {
@@ -65,23 +63,48 @@ export function useMonitor() {
         playCriticalAlert();
       }
 
+      lastEventRef.current = Date.now();
       setState((prev) => {
+        const base: MonitorState = {
+          ...prev,
+          lastEventTimestamp: lastEventRef.current,
+          connected: 'CONNECTED' as ConnectionStatus,
+        };
         if (event.type === 'INFRASTRUCTURE') {
-          // Replace the status entry for this source (keep latest per source)
-          const others = prev.infrastructure.filter((e) => e.source !== event.source);
-          return {
-            ...prev,
-            infrastructure: [event, ...others],
-          };
+          const others = base.infrastructure.filter((e) => e.source !== event.source);
+          return { ...base, infrastructure: [event, ...others] };
         } else {
-          // Prepend to the log, capped at MAX_LOG_ENTRIES
-          const updated = [event, ...prev.logs].slice(0, MAX_LOG_ENTRIES);
-          return { ...prev, logs: updated };
+          const updated = [event, ...base.logs].slice(0, MAX_LOG_ENTRIES);
+          return { ...base, logs: updated };
         }
       });
     },
     [playCriticalAlert],
   );
+
+  // ── Heartbeat checker — STALE at 15s, reconnect at 30s ──────────────────
+  useEffect(() => {
+    if (!active) return;
+
+    staleTimerRef.current = setInterval(() => {
+      if (lastEventRef.current === 0) return;
+      const elapsed = Date.now() - lastEventRef.current;
+      if (elapsed >= RECONNECT_THRESHOLD_MS) {
+        lastEventRef.current = Date.now(); // reset to avoid cascading reconnects
+        setReconnectKey((k) => k + 1);
+        setState((s) => ({ ...s, connected: 'CONNECTING' }));
+      } else if (elapsed >= STALE_THRESHOLD_MS) {
+        setState((s) => (s.connected === 'CONNECTED' ? { ...s, connected: 'STALE' } : s));
+      }
+    }, 1_000);
+
+    return () => {
+      if (staleTimerRef.current) {
+        clearInterval(staleTimerRef.current);
+        staleTimerRef.current = null;
+      }
+    };
+  }, [active]);
 
   // ── SSE connection lifecycle ─────────────────────────────────────────────
   useEffect(() => {
@@ -92,8 +115,11 @@ export function useMonitor() {
     const es = new EventSource(SSE_URL);
     esRef.current = es;
 
-    es.onopen = () => setState((s) => ({ ...s, connected: true }));
-    es.onerror = () => setState((s) => ({ ...s, connected: false }));
+    es.onopen = () => {
+      lastEventRef.current = Date.now();
+      setState((s) => ({ ...s, connected: 'CONNECTED', lastEventTimestamp: lastEventRef.current }));
+    };
+    es.onerror = () => setState((s) => ({ ...s, connected: 'DISCONNECTED' }));
 
     // The backend sends events with name "infrastructure" or "data"
     es.addEventListener('infrastructure', (e: MessageEvent) => {
@@ -114,15 +140,20 @@ export function useMonitor() {
 
     return () => {
       es.close();
-      setState((s) => ({ ...s, connected: false }));
+      setState((s) => ({ ...s, connected: 'DISCONNECTED' }));
     };
-  }, [active, handleEvent, initAudio]);
+  }, [active, reconnectKey, handleEvent, initAudio]);
 
   const start = useCallback(() => setActive(true), []);
   const stop = useCallback(() => {
     setActive(false);
+    if (staleTimerRef.current) {
+      clearInterval(staleTimerRef.current);
+      staleTimerRef.current = null;
+    }
     esRef.current?.close();
     esRef.current = null;
+    lastEventRef.current = 0;
   }, []);
 
   return { state, active, start, stop };

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,5 +1,6 @@
 export type Severity = 'INFO' | 'WARNING' | 'CRITICAL';
 export type EventType = 'DATA' | 'INFRASTRUCTURE';
+export type ConnectionStatus = 'CONNECTED' | 'CONNECTING' | 'STALE' | 'DISCONNECTED';
 
 export interface UnifiedEvent {
   type: EventType;
@@ -12,5 +13,6 @@ export interface UnifiedEvent {
 export interface MonitorState {
   infrastructure: UnifiedEvent[];
   logs: UnifiedEvent[];
-  connected: boolean;
+  connected: ConnectionStatus;
+  lastEventTimestamp: number;
 }


### PR DESCRIPTION
## Cambios

- Agrega `ConnectionStatus` enum: `CONNECTED | CONNECTING | STALE | DISCONNECTED`
- Agrega `lastEventTimestamp: number` a `MonitorState`
- Implementa heartbeat checker cada 1s: marca STALE si +15s sin eventos
- Auto-reconecta si estado STALE por más de 30s
- Header.tsx actualizado para mostrar LIVE / CONNECTING / STALE / OFFLINE

## AC Verificados ✅
- `lastEventTimestamp` trackea último evento
- `connected` es enum (no boolean)
- STALE detection en +15s
- Auto-reconnect en +30s STALE

## Tipo
- Closes FRONTEND-001